### PR TITLE
[MOSIP-44879] Handling the empty or null S3 region for AWS v2 API

### DIFF
--- a/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
+++ b/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReentrantLock;
 
 import io.mosip.commons.khazana.util.SafeS3InputStream;
+import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang.ArrayUtils;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -154,14 +155,24 @@ public class S3Adapter implements ObjectStoreAdapter, DisposableBean {
     private static final String DEFAULT_S3_REGION = "DEFAULT";
 
     /**
-     * Region id supplied to {@link S3Client} via {@link Region#of(String)} (signing and
-     * endpoint metadata). AWS SDK for Java v2 does not allow a null or empty region id
-     * when building the client. When {@code object.store.s3.region} is unset (empty default),
-     * blank after trimming, Java {@code null}, or the literal string {@code "null"}
-     * (case-insensitive), returns {@link #DEFAULT_S3_REGION} so S3-compatible endpoints
-     * that expect a placeholder region still receive a valid id.
+     * {@link Region} for {@link S3Client}, computed once at bean init from
+     * {@code object.store.s3.region} (unchanged at runtime).
      */
-    private String effectiveS3Region() {
+    private Region resolvedS3Region;
+
+    @PostConstruct
+    void initResolvedS3Region() {
+        resolvedS3Region = Region.of(resolveConfiguredRegionId());
+    }
+
+    /**
+     * Region id from configuration, before {@link Region#of(String)}. AWS SDK for Java v2
+     * does not allow a null or empty region id when building the client. When
+     * {@code object.store.s3.region} is unset (empty default), blank after trimming,
+     * Java {@code null}, or the literal string {@code "null"} (case-insensitive), returns
+     * {@link #DEFAULT_S3_REGION} so S3-compatible endpoints still receive a valid id.
+     */
+    private String resolveConfiguredRegionId() {
         if (region == null) {
             return DEFAULT_S3_REGION;
         }
@@ -515,7 +526,7 @@ public class S3Adapter implements ObjectStoreAdapter, DisposableBean {
                             .credentialsProvider(StaticCredentialsProvider.create(
                                     AwsBasicCredentials.create(accessKey, secretKey)))
                             .endpointOverride(URI.create(url))
-                            .region(Region.of(effectiveS3Region()))
+                            .region(resolvedS3Region)
                             .serviceConfiguration(S3Configuration.builder()
                                     .pathStyleAccessEnabled(true)
                                     .build())

--- a/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
+++ b/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
@@ -76,7 +76,7 @@ public class S3Adapter implements ObjectStoreAdapter, DisposableBean {
     @Value("${object.store.s3.url:null}")
     private String url;
 
-    @Value("${object.store.s3.region:null}")
+    @Value("${object.store.s3.region:}")
     private String region;
 
     @Value("${object.store.connection.max.retry:20}")
@@ -150,6 +150,27 @@ public class S3Adapter implements ObjectStoreAdapter, DisposableBean {
     private static final String TAG_BACKWARD_COMPATIBILITY_ERROR = "Object-prefix is already an object, please choose a different object-prefix name";
 
     private static final String TAG_BACKWARD_COMPATIBILITY_ACCESS_DENIED_ERROR = "Access Denied";
+
+    private static final String DEFAULT_S3_REGION = "DEFAULT";
+
+    /**
+     * Region id supplied to {@link S3Client} via {@link Region#of(String)} (signing and
+     * endpoint metadata). AWS SDK for Java v2 does not allow a null or empty region id
+     * when building the client. When {@code object.store.s3.region} is unset (empty default),
+     * blank after trimming, Java {@code null}, or the literal string {@code "null"}
+     * (case-insensitive), returns {@link #DEFAULT_S3_REGION} so S3-compatible endpoints
+     * that expect a placeholder region still receive a valid id.
+     */
+    private String effectiveS3Region() {
+        if (region == null) {
+            return DEFAULT_S3_REGION;
+        }
+        String effectiveRegion = region.trim();
+        if (effectiveRegion.isEmpty() || "null".equalsIgnoreCase(effectiveRegion)) {
+            return DEFAULT_S3_REGION;
+        }
+        return effectiveRegion;
+    }
 
     /**
      * Closes the S3Client and releases the underlying Apache HTTP connection pool.
@@ -494,7 +515,7 @@ public class S3Adapter implements ObjectStoreAdapter, DisposableBean {
                             .credentialsProvider(StaticCredentialsProvider.create(
                                     AwsBasicCredentials.create(accessKey, secretKey)))
                             .endpointOverride(URI.create(url))
-                            .region(Region.of(region))
+                            .region(Region.of(effectiveS3Region()))
                             .serviceConfiguration(S3Configuration.builder()
                                     .pathStyleAccessEnabled(true)
                                     .build())


### PR DESCRIPTION
[MOSIP-44879] Handling the empty or null S3 region for AWS v2 API

[MOSIP-44879]: https://mosip.atlassian.net/browse/MOSIP-44879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust S3 region handling: missing, blank, or literal "null" values are now detected and a safe default region is applied to prevent errors.
  * Region resolution is now determined at startup and reused by the S3 client to improve reliability and avoid runtime misconfiguration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->