### PR TITLE
MOSIP-44843: Reverted the AWS SDKV2 version

### DIFF
--- a/kernel/object-store/pom.xml
+++ b/kernel/object-store/pom.xml
@@ -34,7 +34,7 @@
             AWS SDK v2 (modular): s3 + apache-client.
             Update to the latest GA release as needed — API is stable across 2.x.
         -->
-        <aws.sdkv2.version>2.42.28</aws.sdkv2.version>
+        <aws.sdkv2.version>2.26.31</aws.sdkv2.version>
         <joss.adapter.version>0.10.2</joss.adapter.version>
         <mockito.core.version>3.3.3</mockito.core.version>
 

--- a/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
+++ b/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
@@ -870,13 +870,19 @@ public class S3Adapter implements ObjectStoreAdapter, DisposableBean {
      */
     private RequestBody toRequestBody(InputStream data) {
         try {
+            // Fast path: ByteArrayInputStream and most MOSIP streams report exact size.
+            // fromInputStream() streams directly without a full heap copy.
+            int available = data.available();
+            if (available > 0)
+                return RequestBody.fromInputStream(data, available);
+            // Fallback: unknown-length streams must be buffered; SDK v2 requires content-length.
             return RequestBody.fromBytes(data.readAllBytes());
         } catch (IOException e) {
-            throw new ObjectStoreAdapterException(OBJECT_STORE_NOT_ACCESSIBLE.getErrorCode(),
+            throw new ObjectStoreAdapterException(
+                    OBJECT_STORE_NOT_ACCESSIBLE.getErrorCode(),
                     OBJECT_STORE_NOT_ACCESSIBLE.getErrorMessage(), e);
         }
     }
-
     /**
      * Applies bucket prefix and lowercases per S3 naming rules.
      */

--- a/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
+++ b/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
@@ -870,19 +870,13 @@ public class S3Adapter implements ObjectStoreAdapter, DisposableBean {
      */
     private RequestBody toRequestBody(InputStream data) {
         try {
-            // Fast path: ByteArrayInputStream and most MOSIP streams report exact size.
-            // fromInputStream() streams directly without a full heap copy.
-            int available = data.available();
-            if (available > 0)
-                return RequestBody.fromInputStream(data, available);
-            // Fallback: unknown-length streams must be buffered; SDK v2 requires content-length.
             return RequestBody.fromBytes(data.readAllBytes());
         } catch (IOException e) {
-            throw new ObjectStoreAdapterException(
-                    OBJECT_STORE_NOT_ACCESSIBLE.getErrorCode(),
+            throw new ObjectStoreAdapterException(OBJECT_STORE_NOT_ACCESSIBLE.getErrorCode(),
                     OBJECT_STORE_NOT_ACCESSIBLE.getErrorMessage(), e);
         }
     }
+
     /**
      * Applies bucket prefix and lowercases per S3 naming rules.
      */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS SDK v2 dependency to version 2.26.31

* **Performance**
  * Optimized object storage streaming to reduce memory usage by streaming data directly instead of buffering entire payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->